### PR TITLE
issue-8-reviews

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -83,12 +83,26 @@ class Image < ApplicationRecord
     update!(status: :in_review)
   end
 
-  # in_review -> approved
+ # in_review -> approved
   def approve!(reviewer)
     raise StateMachineError, 'Image is not in review' unless in_review?
     raise StateMachineError, 'User must be a reviewer' unless reviewer.reviewer?
     
-    update!(status: :approved)
+    transaction do
+      # Encontra a última anotação feita (a que está sendo revisada)
+      annotation = annotations.order(created_at: :desc).first
+      raise StateMachineError, 'Nenhuma anotação encontrada para aprovar' unless annotation
+
+      # Cria o registro de revisão como Aprovado (usando o enum 0)
+      Review.create!(
+        annotation: annotation,
+        reviewer: reviewer,
+        status: :approved
+      )
+      
+      # Sela a imagem
+      update!(status: :approved)
+    end
   end
 
   # in_review -> rejected
@@ -97,9 +111,22 @@ class Image < ApplicationRecord
     raise StateMachineError, 'User must be a reviewer' unless reviewer.reviewer?
     
     transaction do
+      # Encontra a última anotação feita (a que está sendo rejeitada)
+      annotation = annotations.order(created_at: :desc).first
+      raise StateMachineError, 'Nenhuma anotação encontrada para rejeitar' unless annotation
+
+      # Cria o registro de revisão como Rejeitado (usando o enum 1)
+      Review.create!(
+        annotation: annotation,
+        reviewer: reviewer,
+        status: :rejected
+      )
+      
+      # Pune o erro: devolve a imagem para a fila, sem dono e sem tempo!
       update!(
-        status: :reserved,
-        reserved_at: Time.current
+        status: :available,
+        reserver: nil,
+        reserved_at: nil
       )
     end
   end

--- a/spec/requests/images_spec.rb
+++ b/spec/requests/images_spec.rb
@@ -339,4 +339,81 @@ RSpec.describe 'Images', type: :request do
       end
     end
   end
+  # ==========================================
+  # INÍCIO DOS TESTES DA ISSUE #8 (REVISÃO)
+  # ==========================================
+  describe 'Sistema de Revisão (Issue #8)' do
+    # Criamos uma imagem já no status 'in_review'
+    let(:image_in_review) { create(:image, status: :in_review, reserver: annotator, uploader: admin) }
+    
+    # Criamos a anotação amarrada a essa imagem (o trabalho que o aluno enviou)
+    let!(:annotation) { create(:annotation, image: image_in_review, user: annotator) }
+
+    describe 'POST /images/:id/approve' do
+      context 'quando logado como revisor' do
+        before do
+          login_as(reviewer)
+          post "/images/#{image_in_review.id}/approve"
+        end
+
+        it 'retorna status 200 OK' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'muda o status da imagem para approved' do
+          expect(image_in_review.reload.status).to eq('approved')
+        end
+
+        it 'cria um registro de review com status approved' do
+          review = Review.last
+          expect(review).not_to be_nil
+          expect(review.annotation_id).to eq(annotation.id)
+          expect(review.reviewer_id).to eq(reviewer.id)
+          expect(review.status).to eq('approved')
+        end
+      end
+
+      context 'quando um aluno tenta aprovar a própria imagem' do
+        before do
+          login_as(annotator)
+          post "/images/#{image_in_review.id}/approve"
+        end
+
+        it 'bloqueia a ação e retorna forbidden' do
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    describe 'POST /images/:id/reject' do
+      context 'quando logado como revisor' do
+        before do
+          login_as(reviewer)
+          post "/images/#{image_in_review.id}/reject"
+        end
+
+        it 'retorna status 200 OK' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'devolve a imagem para a fila (available, sem dono e sem tempo)' do
+          image_in_review.reload
+          expect(image_in_review.status).to eq('available')
+          expect(image_in_review.reserver_id).to be_nil
+          expect(image_in_review.reserved_at).to be_nil
+        end
+
+        it 'cria um registro de review com status rejected' do
+          review = Review.last
+          expect(review).not_to be_nil
+          expect(review.annotation_id).to eq(annotation.id)
+          expect(review.reviewer_id).to eq(reviewer.id)
+          expect(review.status).to eq('rejected')
+        end
+      end
+    end
+  end
+  # ==========================================
+  # FIM DOS TESTES DA ISSUE #8
+  # ==========================================
 end


### PR DESCRIPTION
O que foi implementado:

    Máquina de Estados (app/models/image.rb):

        Aprovação (approve!): Altera o status da imagem para approved e cria automaticamente um registro na tabela reviews vinculando a anotação ao revisor com o status approved (0).

        Rejeição (reject!): Altera o status da imagem de volta para available, limpa o reserver_id e o reserved_at (devolvendo a imagem para a fila pública). Também cria o registro na tabela reviews com o status rejected (1).

        Segurança Transacional: Ambas as ações estão encapsuladas em blocos transaction do para garantir que o status da imagem só mude se o registro de revisão for salvo com sucesso.

    Segurança e Autorização:

        Mantidas as validações do controlador que garantem que apenas revisores possam acessar os endpoints /approve e /reject (alunos recebem erro 403 Forbidden).

    Testes Automatizados (RSpec):

        Adicionado bloco de testes de integração no images_spec.rb cobrindo o fluxo feliz de aprovação, o fluxo de rejeição (com verificação de reset de dono/tempo) e o bloqueio de segurança contra acessos indevidos.

🧪 Como testar localmente:

    Baixe a branch: git checkout issue-8-reviews

    Rode a suíte de testes de revisão:
    Bash

    docker-compose exec web env RAILS_ENV=test bundle exec rspec spec/requests/images_spec.rb -e "Sistema de Revisão"

    O resultado esperado são 7 testes passando em verde (7 examples, 0 failures).